### PR TITLE
[fix] full_write에서 ssd_write를 _write 사용하는 것으로 수정

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -11,8 +11,9 @@ class Shell:
     def __init__(self):
         self.ssd = SSD()
 
-    def _ssd_reset(self):
-        self.ssd.reset_ssd()
+    def _ssd_reset(self, reset_val=f"{0:#08X}"):
+        for idx in range(self.MIN_INDEX, self.MAX_INDEX):
+            self._write(idx, reset_val)
 
     def read(self, lba: int):
         line = self._read(lba)
@@ -47,7 +48,7 @@ class Shell:
 
     def full_write(self, value):
         for lba in range(self.MAX_INDEX):
-            self.ssd.write(lba, value)
+            self._write(lba, value)
         print(f"[Full Write] Done")
 
     def fullread(self):

--- a/test_shell.py
+++ b/test_shell.py
@@ -35,11 +35,11 @@ def test_write(capsys, mocker :MockerFixture):
     mock_write.assert_called_once_with(3, value)
 
 
-def test_write_all_success(mocker: MockerFixture):
-    value = 0xAAAABBBB
+def test_full_write_success(mocker: MockerFixture):
+    ssd_write_mock = mocker.patch('shell.Shell._write')
+    value = hex(0xAAAABBBB)
     shell = Shell()
     shell._ssd_reset()
-    ssd_write_mock = mocker.patch('ssd.SSD.write')
     full_call_list = [call(idx, value) for idx in range(100)]
     shell.full_write(value)
     ssd_write_mock.assert_has_calls(full_call_list)


### PR DESCRIPTION
1. full_read 기능과 테스트에서 shell._write를 사용하도록 수정
2. _ssd_reset에서 shell._write를 사용하도록 수정