### PR TITLE
[refact] remove _ssd_reset call

### DIFF
--- a/test_shell.py
+++ b/test_shell.py
@@ -51,7 +51,6 @@ def test_full_write_success(mocker: MockerFixture):
     ssd_write_mock = mocker.patch('shell.Shell._write')
     value = hex(0xAAAABBBB)
     shell = Shell()
-    shell._ssd_reset()
     full_call_list = [call(idx, value) for idx in range(100)]
     shell.full_write(value)
     ssd_write_mock.assert_has_calls(full_call_list)
@@ -66,7 +65,6 @@ def test_help_call(mocker: MockerFixture):
 
 def test_help_text_valid(capsys):
     shell = Shell()
-    shell._ssd_reset()
     ret = shell.help()
     captured = capsys.readouterr()
 


### PR DESCRIPTION
 _ssd_reset이 불리면서 시간을 5초 정도 더 걸리게 하고 있습니다.
해당 부분은 불리지 않아도 테스트에 영향없는 부분이라 삭제합니다.
