### PR TITLE
[fix] test_full_read mock객체를 사용 하도록 변경

### DIFF
--- a/test_shell.py
+++ b/test_shell.py
@@ -185,8 +185,9 @@ def test_full_read_call(mocker:MockerFixture):
 
 
 def test_full_read_valid(mocker:MockerFixture, capsys):
+    mk_full_read = mocker.patch('shell.Shell._read')
+    mk_full_read.return_value = '0x00000000'
     shell = Shell()
-
     shell.full_read()
     captured = capsys.readouterr()
     assert captured.out.strip() == '[Full Read]\n' + '\n'.join([f"LBA {i:02d} : 0x00000000" for i in range(100)])


### PR DESCRIPTION
Test 속도 향상을 위하여,
_read 실행 시, Mock patch 결과를 return 하도록 변경 하였습니다.