### PR TITLE
[fix] 숫자 포맷 자리수 10으로 변경

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -70,7 +70,7 @@ class Shell:
         block_length = 5
         for block_idx in range(ssd_length // block_length):
             random_val = random.randint(0x00000001, 0xFFFFFFFF)
-            random_val = f"{random_val:#08X}"
+            random_val = f"{random_val:#010X}"
             remove_duplicates = set()
             for inner_idx in range(block_length):
                 idx = block_idx * block_length + inner_idx
@@ -103,7 +103,7 @@ class Shell:
     def WriteReadAging(self):
         for _ in range(200):
             random_val = random.randint(0x00000000, 0xFFFFFFFF)
-            write_value = f"{random_val:#08X}"
+            write_value = f"{random_val:#010X}"
             self._write(0, write_value)
             self._write(99, write_value)
             if self._read(0).strip() != self._read(99).strip():

--- a/test_shell.py
+++ b/test_shell.py
@@ -143,8 +143,8 @@ def test_full_write_and_read_compare_success(mocker:MockerFixture, capsys):
     for i in range(ssd_length // block_length):
         random_val = random.randint(0x00000001, 0xFFFFFFFF)
         for j in range(block_length):
-            random_values.append(f'{random_val:#08X}')
-            write_calls.append(call(i * block_length + j, f'{random_val:#08X}'))
+            random_values.append(f'{random_val:#010X}')
+            write_calls.append(call(i * block_length + j, f'{random_val:#010X}'))
             read_calls.append(call(i * block_length + j))
     shell_read_mock.side_effect = random_values
     random.seed(seed)
@@ -168,8 +168,8 @@ def test_full_write_and_read_compare_fail(mocker:MockerFixture, capsys):
     for i in range(ssd_length // block_length):
         random_val = random.randint(0x00000001, 0xFFFFFFFF)
         for j in range(block_length):
-            random_values.append(f'{random_val:#08X}')
-            write_calls.append(call(i * block_length + j, f'{random_val:#08X}'))
+            random_values.append(f'{random_val:#010X}')
+            write_calls.append(call(i * block_length + j, f'{random_val:#010X}'))
             read_calls.append(call(i * block_length + j))
     shell_read_mock.side_effect = random_values
     random.seed(seed+1)


### PR DESCRIPTION
1. `#08X`로 포매팅 시 자리수가 부족함 0X를 포함해 10자리가 필요하므로 `#010X`로 변경했습니다.