### PR TITLE
[feat] erase range 기능 추가

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -101,6 +101,19 @@ class Shell:
         print("[Erase] Done")
 
 
+    def erase_range(self, start_lba, end_lba):
+        if not (self.MIN_INDEX <= start_lba
+                and start_lba <= end_lba
+                and end_lba < self.MAX_INDEX):
+            self.logger.print("[Erase Range] ERROR")
+            print("[Erase Range] ERROR")
+            return
+        for start in range(start_lba, end_lba + 1, 10):
+            end = min(end_lba + 1 - start, 10)
+            self._erase(start, end)
+        print("[Erase Range] Done")
+
+
     def full_write(self, value):
         for lba in range(self.MAX_INDEX):
             self._write(lba, value)
@@ -196,7 +209,7 @@ def checkInvalid(user_input_list):
         return True
 
     cmd_type = user_input_list[0]
-    if cmd_type not in ['read', 'write', 'exit', 'help', 'fullwrite', 'fullread', '1_', '1_FullWriteAndReadCompare', '2_', '2_PartialLBAWrite', '3_', '3_WriteReadAging', '4_', '4_EraseAndWriteAging']:
+    if cmd_type not in ['read', 'write', 'erase', 'erase_range', 'exit', 'help', 'fullwrite', 'fullread', '1_', '1_FullWriteAndReadCompare', '2_', '2_PartialLBAWrite', '3_', '3_WriteReadAging', '4_', '4_EraseAndWriteAging']:
         return True
 
     try:
@@ -230,6 +243,14 @@ def startShell(shell: Shell):
             lba = int(user_input_list[1])
             address = user_input_list[2]
             shell.write(lba, address)
+        elif cmd_type == "erase":
+            start_lba = int(user_input_list[1])
+            size = int(user_input_list[2])
+            shell.erase(start_lba, size)
+        elif cmd_type == "erase_range":
+            start_lba = int(user_input_list[1])
+            end_lba = int(user_input_list[2])
+            shell.erase_range(start_lba, end_lba)
         elif cmd_type == "exit":
             break
         elif cmd_type == "help":

--- a/test_shell.py
+++ b/test_shell.py
@@ -308,3 +308,15 @@ def test_erase(mocker: MockerFixture, capsys):
     calls = [call(start, min(lba + size - start, 10)) for start in range(lba, lba + size, 10)]
     mock_erase.assert_has_calls(calls)
     assert captured.strip() == "[Erase] Done"
+
+
+def test_erase_range(mocker: MockerFixture, capsys):
+    mock_erase_range = mocker.patch('shell.Shell._erase')
+    shell = Shell()
+    start_lba = 0
+    end_lba = 98
+    shell.erase_range(start_lba, end_lba)
+    captured = capsys.readouterr().out
+    calls = [call(start, min(end_lba + 1 - start, 10)) for start in range(start_lba, end_lba + 1, 10)]
+    mock_erase_range.assert_has_calls(calls)
+    assert captured.strip() == "[Erase Range] Done"


### PR DESCRIPTION
1. `erase_range(start_lba, end_lba`) 메서드 추가 : [start_lba, end_lba] 범위를 삭제한다
2. `test_erase_range` 에서 적합한 _erase가 호출되는지 확인
3. `shell startShel`l에 erase와 erase_range 커멘드를 받도록 추가