### PR TITLE
[fix] checkInvalid 변경

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -230,7 +230,7 @@ def checkInvalid(user_input_list):
                 user_input_list[2]
                 if not (0 <= lba < 100):
                     return True
-        if cmd_type == "erase" or "erase_range":
+        if cmd_type == "erase" or cmd_type == "erase_range":
             int(user_input_list[1])
             int(user_input_list[2])
         if cmd_type == "fullwrite":


### PR DESCRIPTION
기존 if cmd_type == "erase" or "erase_range":
수행 시 항상 참으로 들어가 INVALID COMMAND 발생