### PR TITLE
[refactor] ssd test fixture로 분ë¦리 및 동일 로직 파라미터화

### DIFF
--- a/test_ssd.py
+++ b/test_ssd.py
@@ -5,66 +5,55 @@ import pytest
 from ssd import SSD
 
 
-def test_ssd_write_error_1():
-    ssd = SSD()
-    ssd.reset_ssd()
-    ssd.write(-1, '0x00113456')
+@pytest.fixture
+def ssd():
+    ssd_ = SSD()
+    ssd_.reset_ssd()
+    return ssd_
+
+
+@pytest.mark.parametrize(
+    "test_params",
+    [(-1, '0x00113456', "ERROR"),
+     (-987, '0x00113456', "ERROR"),
+     (2, '0x00113456', ""),
+     (99, '0xFF34FF33', "")]
+)
+def test_ssd_write_with_params(test_params, ssd: SSD):
+    lba, value, expected = test_params
+
+    ssd.write(lba, value)
     output = ssd.read_output()
-    assert output == "ERROR"
+
+    assert output == expected
 
 
-def test_ssd_write_error_2():
-    ssd = SSD()
-    ssd.reset_ssd()
-    ssd.write(987, '0x00113456')
-    output = ssd.read_output()
-    assert output == "ERROR"
+@pytest.mark.parametrize(
+    "address, expected",
+    [(-1, False),
+     (100, False),
+     ('asd', False),
+     (0, True),
+     (99, True)]
+)
+def test_ssd_write_address_validation(address, expected: bool, ssd: SSD):
+    assert ssd.is_valid_address(address) is expected
 
 
-def test_ssd_write_pass_1():
-    ssd = SSD()
-    ssd.reset_ssd()
-    ssd.write(2, '0x00113456')
-    contents = ssd.read_all()
-    output = ssd.read_output()
-    assert contents[2] == f"02 0x00113456\n" and output == ""
+@pytest.mark.parametrize(
+    "value, expected",
+    [('asif', False),
+     ('-123', False),
+     ('0xAabB1234', True),
+     ('4F', True),
+     ('0x01230123', True)]
+)
+def test_ssd_write_value_validation(value, expected: bool, ssd: SSD):
+    assert ssd.is_valid_value(value) is expected
 
 
-def test_ssd_write_pass_2():
-    ssd = SSD()
-    ssd.reset_ssd()
-    ssd.write(99, '0xFF34FF33')
-    contents = ssd.read_all()
-    output = ssd.read_output()
-    assert contents[99] == f"99 0xFF34FF33\n" and output == ""
-
-
-def test_ssd_write_address_validation():
-    ssd = SSD()
-    ssd.reset_ssd()
-
-    assert ssd.is_valid_address(-1) is False
-    assert ssd.is_valid_address(0) is True
-    assert ssd.is_valid_address(99) is True
-    assert ssd.is_valid_address(100) is False
-    assert ssd.is_valid_address('asd') is False
-
-
-def test_ssd_write_data_validation():
-    ssd = SSD()
-    ssd.reset_ssd()
-
-    assert ssd.is_valid_value('ass') is False
-    assert ssd.is_valid_value('-123') is False
-    assert ssd.is_valid_value('0xAabB1234') is True
-    assert ssd.is_valid_value('4F') is True
-    assert ssd.is_valid_value('0x01230123') is True
-
-
-def test_read_same_with_output():
+def test_read_same_with_output(ssd: SSD):
     lba = 10
-    ssd = SSD()
-    ssd.reset_ssd()
     ssd.read(lba)
 
     with open(ssd.ssd_nand, 'r', encoding='utf-8') as file:
@@ -80,10 +69,8 @@ def test_read_same_with_output():
     assert nand_value.strip() == output.strip()
 
 
-def test_read_invalid_lba_access():
+def test_read_invalid_lba_access(ssd: SSD):
     lba = 100
-    ssd = SSD()
-    ssd.reset_ssd()
     ssd.read(lba)
 
     with open(ssd.ssd_output, 'r', encoding='utf-8') as file:
@@ -108,7 +95,7 @@ def test_write_and_read_command_line():
     output = 'ssd_output.txt'
     with open(output, 'r', encoding='utf-8') as file:
         line = file.readline()
-    assert  line.strip() == f"0x1298CDEF"
+    assert line.strip() == f"0x1298CDEF"
 
 
 def test_erase_and_read_command_line():
@@ -127,7 +114,7 @@ def test_erase_and_read_command_line():
     output = 'ssd_output.txt'
     with open(output, 'r', encoding='utf-8') as file:
         line = file.readline()
-    assert  line.strip() == f"0x00000000"
+    assert line.strip() == f"0x00000000"
 
 
 def test_erase_oversize_error():
@@ -140,7 +127,7 @@ def test_erase_oversize_error():
     output = 'ssd_output.txt'
     with open(output, 'r', encoding='utf-8') as file:
         line = file.readline()
-    assert  line.strip() == "ERROR"
+    assert line.strip() == "ERROR"
 
 
 def test_erase_invalid_start_lba_error():
@@ -153,7 +140,7 @@ def test_erase_invalid_start_lba_error():
     output = 'ssd_output.txt'
     with open(output, 'r', encoding='utf-8') as file:
         line = file.readline()
-    assert  line.strip() == "ERROR"
+    assert line.strip() == "ERROR"
 
 
 def test_erase_invalid_last_lba_error():
@@ -166,4 +153,4 @@ def test_erase_invalid_last_lba_error():
     output = 'ssd_output.txt'
     with open(output, 'r', encoding='utf-8') as file:
         line = file.readline()
-    assert  line.strip() == "ERROR"
+    assert line.strip() == "ERROR"


### PR DESCRIPTION
1. test_ssd에서 중복사용되던 ssd를 pytest.fixture로 분리
2. 같은 로직을 사용하는 테스트를 parametrize로 수정