### PR TITLE
[fix] runner file 내, 실행 script의 이름이 잘 못 된 경우 break 되도록 변경

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -370,7 +370,8 @@ def start_runner(shell: Shell, file_path):
                     if not test_run_and_pass_check(shell.erase_and_write_aging):
                         break
                 else:
-                    continue
+                    print('INVALID COMMAND')
+                    break
     except:
         print('INVALID COMMAND')
 


### PR DESCRIPTION
runner file 내, 실행 script의 이름이 잘 못 된 경우 break 되도록 변경 했습니다.