### PR TITLE
[fix] erase_range 함수이름 변경으로 인한 오류 수정

### DIFF
--- a/test_shell.py
+++ b/test_shell.py
@@ -312,7 +312,7 @@ def test_erase_range(mocker: MockerFixture, capsys):
 def test_erase_and_write_aging(mocker):
     shell = Shell()
     # erase_range, _write 메서드를 mock
-    erase_range_mock = mocker.patch.object(shell, 'erase_range')
+    erase_range_mock = mocker.patch.object(shell, '_erase_range')
     write_mock = mocker.patch.object(shell, '_write')
     shell.erase_and_write_aging(loop=1)
 


### PR DESCRIPTION
`erase_range`에서 `_erase_range`로 변경됐을 때 같이 변경되지 않아 발생한 테스트 오류 수정