### PR TITLE
[fix] write 성공 후 ssd_output.txt 출력을 안해주는 오류수정

### DIFF
--- a/ssd.py
+++ b/ssd.py
@@ -70,6 +70,7 @@ class SSD:
         if not self.buffer.write('W', lba, value):
             self.flush()
             self.buffer.write('W', lba, value)
+        self.write_output('')
 
     def _write(self, lba: int, value: str):
         contents = self.read_all()


### PR DESCRIPTION
이로 인해 ssd_output.txt에 ERROR가 남아있으면 테스트 수행 시 정상 작동시에도 계속해서 오류가 발생했다고 뜨는 현상 해결
ssd write에 ssd_output.txt 결과 출력 추가